### PR TITLE
fix: usage of PreviewPane

### DIFF
--- a/plugins/previewPane/PreviewPane.tsx
+++ b/plugins/previewPane/PreviewPane.tsx
@@ -1,5 +1,6 @@
 import { Card, Text } from '@sanity/ui'
 import { resolveHref } from 'lib/sanity.links'
+import { apiVersion, previewSecretId } from 'lib/sanity.api'
 import { getSecret } from 'plugins/productionUrl/utils'
 import { ComponentProps, Suspense } from 'react'
 import { memo } from 'react'
@@ -20,12 +21,9 @@ interface IframeProps {
 }
 
 export function PreviewPane(
-  props: PreviewProps & {
-    previewSecretId: `${string}.${string}`
-    apiVersion: string
-  }
+  props: PreviewProps
 ) {
-  const { document, previewSecretId, apiVersion } = props
+  const { document } = props
   const { displayed } = document
   const documentType = displayed?._type
   let slug = (displayed?.slug as any)?.current

--- a/plugins/settings.tsx
+++ b/plugins/settings.tsx
@@ -2,7 +2,6 @@
  * This plugin contains all the logic for setting up the singletons
  */
 
-import { apiVersion, previewSecretId } from 'lib/sanity.api'
 import { type DocumentDefinition } from 'sanity'
 import { type StructureResolver } from 'sanity/desk'
 
@@ -59,17 +58,7 @@ export const pageStructure = (
               S.view.form(),
               // Preview
               ...(PREVIEWABLE_DOCUMENT_TYPES.includes(typeDef.name)
-                ? [
-                    S.view
-                      .component((props) => (
-                        <PreviewPane
-                          previewSecretId={previewSecretId}
-                          apiVersion={apiVersion}
-                          {...props}
-                        />
-                      ))
-                      .title('Preview'),
-                  ]
+                ? [S.view.component(PreviewPane).title('Preview')]
                 : []),
             ])
         )


### PR DESCRIPTION
This is just a follow up PR based on my [comment](https://sanity-io-land.slack.com/archives/C9Z7RC3V1/p1686757172004499) in the Slack channel. For some reason the current usage will give a weird Type error saying `PreviewPane` refers to a value but is being used as a type. Even looking at the [documentation](https://www.sanity.io/docs/create-custom-document-views-with-structure-builder) for creating custom document views, it recommends this approach. 


![](https://files.slack.com/files-pri/T9Y440GN8-F05D7K4R5DE/screenshot_2023-06-14_at_8.32.14_am.png)
